### PR TITLE
Adding Control Flow Guard (and other build settings) to C++ Samples

### DIFF
--- a/samples/cpp/ATTEST-UNWRAP-KEY/ATTEST-UNWRAP-KEY/ATTEST-UNWRAP-KEY.vcxproj
+++ b/samples/cpp/ATTEST-UNWRAP-KEY/ATTEST-UNWRAP-KEY/ATTEST-UNWRAP-KEY.vcxproj
@@ -106,3 +106,4 @@
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
 </Project>
+

--- a/samples/cpp/ECDH-KDF-AESCBC/ECDH-KDF-AESCBC/ECDH-KDF-AESCBC.vcxproj
+++ b/samples/cpp/ECDH-KDF-AESCBC/ECDH-KDF-AESCBC/ECDH-KDF-AESCBC.vcxproj
@@ -96,3 +96,4 @@
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
 </Project>
+

--- a/samples/cpp/QUERY-PROPERTIES/QUERY-PROPERTIES/QUERY-PROPERTIES.vcxproj
+++ b/samples/cpp/QUERY-PROPERTIES/QUERY-PROPERTIES/QUERY-PROPERTIES.vcxproj
@@ -96,3 +96,4 @@
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
 </Project>
+

--- a/samples/cpp/RSA-IMPORT-ENCRYPT-DECRYPT/RSA-IMPORT-ENCRYPT-DECRYPT/RSA-IMPORT-ENCRYPT-DECRYPT.vcxproj
+++ b/samples/cpp/RSA-IMPORT-ENCRYPT-DECRYPT/RSA-IMPORT-ENCRYPT-DECRYPT/RSA-IMPORT-ENCRYPT-DECRYPT.vcxproj
@@ -105,3 +105,4 @@
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
 </Project>
+


### PR DESCRIPTION
This PR adds the following build settings to each of the C++ samples:

* [`/guard:cf`](https://learn.microsoft.com/en-us/cpp/build/reference/guard-enable-control-flow-guard) (Control Flow Guard)
* [`/guard:ehcont`](https://learn.microsoft.com/en-us/cpp/build/reference/guard-enable-eh-continuation-metadata) (EH Continuation Metadata)
* [`/DYNAMICBASE`](https://learn.microsoft.com/en-us/cpp/build/reference/dynamicbase-use-address-space-layout-randomization) (Address Space Layout Randomization)
* [`/CETCOMPAT`](https://learn.microsoft.com/en-us/cpp/build/reference/cetcompat) (CET Shadow Stack)