### PR TITLE
C++ Sample Updates - KBKDF Removal, Key Free/Delete Behavior, Cert Chain Property Removal, Etc.

### DIFF
--- a/docs/Overview.md
+++ b/docs/Overview.md
@@ -35,6 +35,5 @@ The following cryptographic operations are supported by AziHSM:
         * ECC P384
         * ECC P521
 * **Key Derivation**
-    * KBKDF ("Key Based Key Derivation Function") - refers to the **SP800-108 HMAC in counter mode** KDF, as seen [here](https://learn.microsoft.com/en-us/windows/win32/api/bcrypt/nf-bcrypt-bcryptkeyderivation) in the NCrypt API documentation.
     * HKDF ("HMAC-based Key Derivation Function") - as defined in [IETF RFC 5869](https://datatracker.ietf.org/doc/html/rfc5869), and referred to in NCrypt by the `BCRYPT_HKDF_ALGORITHM` string.
 

--- a/samples/cpp/ATTEST-UNWRAP-KEY/ATTEST-UNWRAP-KEY/ATTEST-UNWRAP-KEY.cpp
+++ b/samples/cpp/ATTEST-UNWRAP-KEY/ATTEST-UNWRAP-KEY/ATTEST-UNWRAP-KEY.cpp
@@ -353,7 +353,33 @@ static SECURITY_STATUS import_wrapped_key(
 cleanup:
     if (importedKey)
     {
-        NCryptFreeObject(importedKey);
+        // Call `NCryptDeleteKey` to delete the partially-imported key (and
+        // free the key handle) if we failed any of the above import steps.
+        SECURITY_STATUS cleanup_status = NCryptDeleteKey(importedKey, 0);
+        if (FAILED(cleanup_status))
+        {
+            fprintf(stderr, "Failed to delete imported key during cleanup. "
+                    "NCryptDeleteKey returned: 0x%08x\n",
+                    cleanup_status);
+
+            // If we failed to delete the key during cleanup, try to free the
+            // key handle.
+            cleanup_status = NCryptFreeObject(importedKey);
+            if (FAILED(cleanup_status))
+            {
+                fprintf(stderr, "Failed to free imported key handle during cleanup. "
+                        "NCryptFreeObject returned: 0x%08x\n",
+                        cleanup_status);
+            }
+            else
+            {
+                importedKey = NULL;
+            }
+        }
+        else
+        {
+            importedKey = NULL;
+        }
     }
     return status;
 }
@@ -805,12 +831,45 @@ cleanup:
 
     if (importedKey)
     {
-        NCryptFreeObject(importedKey);
+        // Call `NCryptDeleteKey` to delete the key (and free the key handle).
+        SECURITY_STATUS cleanup_status = NCryptDeleteKey(importedKey, 0);
+        if (FAILED(cleanup_status))
+        {
+            fprintf(stderr, "Failed to delete imported key during cleanup. "
+                    "NCryptDeleteKey returned: 0x%08x\n",
+                    cleanup_status);
+
+            // If we failed to delete the key during cleanup, try to free the
+            // key handle.
+            cleanup_status = NCryptFreeObject(importedKey);
+            if (FAILED(cleanup_status))
+            {
+                fprintf(stderr, "Failed to free imported key handle during cleanup. "
+                        "NCryptFreeObject returned: 0x%08x\n",
+                        cleanup_status);
+            }
+            else
+            {
+                importedKey = NULL;
+            }
+        }
+        else
+        {
+            importedKey = NULL;
+        }
     }
 
     if (importKey)
     {
-        NCryptFreeObject(importKey);
+        // Free our handle to the AziHSM import key (built-in unwrapping key);
+        // we do not need to delete this key.
+        SECURITY_STATUS cleanup_status = NCryptFreeObject(importKey);
+        if (FAILED(cleanup_status))
+        {
+            fprintf(stderr, "Failed to free imported key handle during cleanup. "
+                    "NCryptFreeObject returned: 0x%08x\n",
+                    cleanup_status);
+        }
     }
 
     if (provider)

--- a/samples/cpp/ECDH-KDF-AESCBC/ECDH-KDF-AESCBC/ECDH-KDF-AESCBC.cpp
+++ b/samples/cpp/ECDH-KDF-AESCBC/ECDH-KDF-AESCBC/ECDH-KDF-AESCBC.cpp
@@ -7,8 +7,8 @@
 //    separate party: "Alice" (party 1) and "Bob" (party 2))
 // 2. Perform ECDH key exchange, to exchange public keys between the two
 //    parties, and generate a shared secret.
-// 3. Use KBKDF or HKDF to derive the same AES key (using the shared secret)
-//    for both parties.
+// 3. Use HKDF to derive the same AES key (using the shared secret) for both
+//    parties.
 // 4. Perform AES-CBC encryption and decryption to verify that the two derived
 //    AES keys are identical.
 //
@@ -39,14 +39,6 @@
 // Force the linking of the NCrypt library into this executable, so we can
 // access NCrypt symbols in our code below:
 #pragma comment(lib, "ncrypt.lib")
-
-// Global settings to toggle between KBKDF and HKDF (By default, this program
-// will use KBKDF.)
-typedef enum _KDFType
-{
-    KDF_TYPE_KBKDF, // Key-Based Key Derivation Function
-    KDF_TYPE_HKDF,  // HMAC-based Key Derivation Function
-} KDFType;
 
 
 // ============================= NCrypt Helpers ============================= //
@@ -101,7 +93,7 @@ static SECURITY_STATUS create_ecdh_key(NCRYPT_PROV_HANDLE provider,
                 status);
         goto cleanup;
     }
-    
+
     // Success; update the return pointer and set a successful return status.
     // Set `key` back to NULL, to move ownership of the key handle to
     // `*result`.
@@ -111,17 +103,34 @@ static SECURITY_STATUS create_ecdh_key(NCRYPT_PROV_HANDLE provider,
 
 cleanup:
     SECURITY_STATUS exit_status = status;
-    
+
     // If the key was not set back to zero, then something went wrong above and
-    // we need to free the key before returning.
+    // we need to delete and free the key before returning.
     if (key != NULL)
     {
-        status = NCryptFreeObject(key);
+        status = NCryptDeleteKey(key, 0);
         if (FAILED(status))
         {
-            fprintf(stderr, "Failed to free ECDH key handle. "
-                    "NCryptFreeObject returned: 0x%08x\n",
+            fprintf(stderr, "Failed to delete ECDH key. "
+                    "NCryptDeleteKey returned: 0x%08x\n",
                     status);
+
+            // If we failed to delete the key, try to free the key handle.
+            status = NCryptFreeObject(key);
+            if (FAILED(status))
+            {
+                fprintf(stderr, "Failed to free ECDH key handle during cleanup. "
+                        "NCryptFreeObject returned: 0x%08x\n",
+                        status);
+            }
+            else
+            {
+                key = NULL;
+            }
+        }
+        else
+        {
+            key = NULL;
         }
     }
 
@@ -157,7 +166,7 @@ static SECURITY_STATUS export_ecdh_key(NCRYPT_KEY_HANDLE key,
                 status);
         goto cleanup;
     }
-    
+
     // Allocate a buffer of the specified size, then invoke `NCryptExportKey()`
     // a second time, to store the exported key.
     buffer = new BYTE[buffer_len];
@@ -187,7 +196,7 @@ static SECURITY_STATUS export_ecdh_key(NCRYPT_KEY_HANDLE key,
     *result_len = buffer_len;
     buffer = NULL;
     status = S_OK;
-    
+
     // Label for cleaning up local resources on error.
 cleanup:
     SECURITY_STATUS exit_status = status;
@@ -229,7 +238,7 @@ static SECURITY_STATUS import_ecdh_key(NCRYPT_PROV_HANDLE provider,
                 status);
         goto cleanup;
     }
-    
+
     // Success; set the return pointer and set a success status message.
     // Reset `key` to NULL, to transfer ownership of the key handle to
     // `*result`.
@@ -265,7 +274,7 @@ static SECURITY_STATUS generate_secret(NCRYPT_KEY_HANDLE private_ecdh_key,
                 status);
         goto cleanup;
     }
-    
+
     // Success; set the return pointer and set a success status message
     // Reset `secret` to NULL, to transfer ownership of the secret handle to
     // `*result`.
@@ -275,168 +284,6 @@ static SECURITY_STATUS generate_secret(NCRYPT_KEY_HANDLE private_ecdh_key,
 
 cleanup:
     SECURITY_STATUS exit_status = status;
-    return exit_status;
-}
-
-// Helper function that invokes AziHSM (via NCrypt) with the given secret
-// handle to derive an AES key, using KBKDF.
-static SECURITY_STATUS derive_aes_key_kbkdf(NCRYPT_PROV_HANDLE provider,
-                                            NCRYPT_SECRET_HANDLE secret,
-                                            size_t key_bit_len,
-                                            PCWSTR hash_alg,
-                                            const wchar_t* context,
-                                            const size_t context_len,
-                                            const wchar_t* label,
-                                            const size_t label_len,
-                                            NCRYPT_KEY_HANDLE* result)
-{
-    SECURITY_STATUS status = S_OK;
-    NCRYPT_KEY_HANDLE key = NULL;
-    
-    // Using KBKDF requires using the SP800-108 HMAC in Counter Mode algorithm
-    // identifier when invoking NCrypt.
-    PCWSTR kdf_alg = BCRYPT_SP800108_CTR_HMAC_ALGORITHM;
-
-    // Before calling `NCryptDeriveKey()`, we need to establish an array of
-    // `BCryptBuffer` objects, which we'll pass into `NCryptDeriveKey()` as
-    // parameters.
-    const size_t param_buffers_len = 4;
-    BCryptBuffer param_buffers[param_buffers_len];
-
-    // HASH ALGORITHM: this will tell AziHSM which hashing algorithm we want to
-    // use for key derivation.
-    param_buffers[0].BufferType = KDF_HASH_ALGORITHM;
-    param_buffers[0].cbBuffer = (ULONG) (wcslen(hash_alg) * sizeof(wchar_t));
-    param_buffers[0].pvBuffer = (PVOID) hash_alg;
-    
-    // CONTEXT: The KBKDF Context is a custom string that is factored into the
-    // key derivation process. If two keys are derived from the same secret,
-    // but they have different context strings, the resulting derived key will
-    // be different.
-    param_buffers[1].BufferType = KDF_CONTEXT;
-    param_buffers[1].cbBuffer = (ULONG) context_len * sizeof(wchar_t);
-    param_buffers[1].pvBuffer = (PVOID) context;
-    
-    // LABEL: The KBKDF Label plays a similar role to the KBKDF Context. It is
-    // a custom string that is factored into the key derivation process. If two
-    // keys are derived from the same secret, *and* the same context, but they
-    // have different label strings, the resulting derived key will be
-    // different.
-    param_buffers[2].BufferType = KDF_LABEL;
-    param_buffers[2].cbBuffer = (ULONG) label_len * sizeof(wchar_t);
-    param_buffers[2].pvBuffer = (PVOID) label;
-    
-    // KEY BIT LENGTH: Lastly, we need to specify the number of bits we want
-    // our derived AES key to be.
-    const uint32_t key_bit_length = (uint32_t) key_bit_len;
-    param_buffers[3].BufferType = KDF_KEYBITLENGTH;
-    param_buffers[3].cbBuffer = (ULONG) sizeof(uint32_t);
-    param_buffers[3].pvBuffer = (PVOID) &key_bit_length;
-
-    // Finally, set up a `BCryptBufferDesc` object to contain the array of
-    // `BCryptBuffer` objects.
-    BCryptBufferDesc param_list;
-    param_list.ulVersion = NCRYPTBUFFER_VERSION;
-    param_list.cBuffers = (ULONG) param_buffers_len;
-    param_list.pBuffers = (PBCryptBuffer) param_buffers;
-
-    BYTE* derived_key_buffer = NULL;
-    ULONG derived_key_buffer_len = 0;
-
-    // Now that our parameters are set up, we'll invoke `NCryptDeriveKey()`
-    // once, to determine how many bytes we need to store the result.
-    status = NCryptDeriveKey(
-        secret,
-        kdf_alg,
-        &param_list,
-        NULL,
-        0,
-        &derived_key_buffer_len,
-        0
-    );
-    if (FAILED(status))
-    {
-        fprintf(stderr, "Failed to derive AES key from secret using KBKDF. "
-                "NCryptDeriveKey (call #1) returned: 0x%08x\n",
-                status);
-        goto cleanup;
-    }
-
-    // Allocate a buffer of the specified size, then invoke `NCryptDeriveKey()`
-    // a second time, to store the output data.
-    derived_key_buffer = new BYTE[derived_key_buffer_len];
-    status = NCryptDeriveKey(
-        secret,
-        kdf_alg,
-        &param_list,
-        (PUCHAR) derived_key_buffer,
-        derived_key_buffer_len,
-        &derived_key_buffer_len,
-        0
-    );
-    if (FAILED(status))
-    {
-        fprintf(stderr, "Failed to derive AES key from secret using KBKDF. "
-                "NCryptDeriveKey (call #2) returned: 0x%08x\n",
-                status);
-        goto cleanup;
-    }
-    
-    // The AziHSM's return data from `NCryptDeriveKey()` is different than
-    // other NCrypt Providers. Instead of returning the derived key's raw data
-    // in the output buffer, the AziHSM instead returns a Key Handle in the
-    // output buffer.
-    //
-    // This is done to ensure the derived key does not leave the trusted,
-    // secure hardware environment of the physical AziHSM device.
-    //
-    // The returned key handle can then be re-imported into the AziHSM via
-    // `NCryptImportKey()` in order to use it for encryption operations. We
-    // will do this now.
-
-    // Invoke `NCryptImportKey()` with the `derived_key_buffer` variable used
-    // above to store the result from `NCryptDeriveKey()`.
-    status = NCryptImportKey(
-        provider,
-        NULL,
-        AZIHSM_DERIVED_KEY_IMPORT_BLOB_NAME,
-        NULL,
-        &key,
-        (PBYTE) derived_key_buffer,
-        (DWORD) derived_key_buffer_len,
-        0
-    );
-    if (FAILED(status))
-    {
-        fprintf(stderr, "Failed to import KBKDF-derived AES key. "
-                "NCryptImportKey returned: 0x%08x\n",
-                status);
-        goto cleanup;
-    }
-
-    // With that, we have successfully:
-    //
-    // 1. Derived an AES key from the provided secret.
-    // 2. Imported the resulting key handle back into AziHSM.
-    //
-    // The AES key handle (`*result`) is now ready to be used for
-    // encryption/decryption.
-    
-    // Update the return pointer, and reset `key` to be NULL, to transfer
-    // ownership of the key handle to `*result`.
-    *result = key;
-    key = NULL;
-    status = S_OK;
-    
-    // Label for cleaning up resources during a failure in the key derivation
-    // process.
-cleanup:
-    SECURITY_STATUS exit_status = status;
-
-    // Free the buffer used to store the results from `NCryptDeriveKey()`; we
-    // no longer need it, now that we've re-imported the key
-    delete[] derived_key_buffer;
-
     return exit_status;
 }
 
@@ -470,7 +317,7 @@ static SECURITY_STATUS derive_aes_key_hkdf(NCRYPT_PROV_HANDLE provider,
     param_buffers[0].BufferType = KDF_HASH_ALGORITHM;
     param_buffers[0].cbBuffer = (ULONG) (wcslen(hash_alg) * sizeof(wchar_t));
     param_buffers[0].pvBuffer = (PVOID) hash_alg;
-    
+
     // INFO: The HKDF Info is a custom string that is factored into the key
     // derivation process. If two keys are derived from the same secret, but
     // they have different info strings, the resulting derived key will be
@@ -478,7 +325,7 @@ static SECURITY_STATUS derive_aes_key_hkdf(NCRYPT_PROV_HANDLE provider,
     param_buffers[1].BufferType = KDF_HKDF_INFO;
     param_buffers[1].cbBuffer = (ULONG) info_len * sizeof(wchar_t);
     param_buffers[1].pvBuffer = (PVOID) info;
-    
+
     // SALT: The HKDF Salt plays a similar role to the HKDF Info. It is a
     // custom string that is factored into the key derivation process. If two
     // keys are derived from the same secret, *and* the same info, but they
@@ -487,7 +334,7 @@ static SECURITY_STATUS derive_aes_key_hkdf(NCRYPT_PROV_HANDLE provider,
     param_buffers[2].BufferType = KDF_HKDF_SALT;
     param_buffers[2].cbBuffer = (ULONG) salt_len * sizeof(wchar_t);
     param_buffers[2].pvBuffer = (PVOID) salt;
-    
+
     // KEY BIT LENGTH: Lastly, we need to specify the number of bits we want
     // our derived AES key to be.
     const uint32_t key_bit_length = (uint32_t) key_bit_len;
@@ -543,7 +390,7 @@ static SECURITY_STATUS derive_aes_key_hkdf(NCRYPT_PROV_HANDLE provider,
                 status);
         goto cleanup;
     }
-    
+
     // The AziHSM's return data from `NCryptDeriveKey()` is different than
     // other NCrypt Providers. Instead of returning the derived key's raw data
     // in the output buffer, the AziHSM instead returns a Key Handle in the
@@ -583,13 +430,13 @@ static SECURITY_STATUS derive_aes_key_hkdf(NCRYPT_PROV_HANDLE provider,
     //
     // The AES key handle (`*result`) is now ready to be used for
     // encryption/decryption.
-    
+
     // Update the return pointer, and reset `key` to be NULL, to transfer
     // ownership of the key handle to `*result`.
     *result = key;
     key = NULL;
     status = S_OK;
-    
+
     // Label for cleaning up resources during a failure in the key derivation
     // process.
 cleanup:
@@ -602,92 +449,48 @@ cleanup:
     return exit_status;
 }
 
-// Helper function that differentiates between the two possible KDF types
-// (KBKDF and HKDF) to derive an AES key.
-// This function invokes the two helper functions defined above based on the
-// provided `kdf` parameter:
-//
-// * `KDF_TYPE_KBKDF` --> `derive_aes_key_kbkdf()`
-// * `KDF_TYPE_HKDF` --> `derive_aes_key_hkdf()`
+// Helper function that derives an AES key from the provided secret handle (and
+// other provided information).
 static SECURITY_STATUS derive_aes_key(NCRYPT_PROV_HANDLE provider,
                                       NCRYPT_SECRET_HANDLE secret,
                                       size_t key_bit_len,
                                       PCWSTR hash_alg,
-                                      KDFType kdf,
                                       NCRYPT_KEY_HANDLE* result)
 {
     SECURITY_STATUS status = S_OK;
     NCRYPT_KEY_HANDLE key = NULL;
 
-    // Differentiate between the two possible KDF types:
-    if (kdf == KDF_TYPE_KBKDF)
+    // Define parameters used by HKDF: the info and salt.
+    // Both of these parameters influence the resulting derived key. We want
+    // Alice and Bob (our two parties) to derive the *same* AES key, so we
+    // choose to use constant values here.
+    const wchar_t* hkdf_info = L"info";
+    const size_t hkdf_info_len = wcslen(hkdf_info);
+    const wchar_t* hkdf_salt = L"salt";
+    const size_t hkdf_salt_len = wcslen(hkdf_salt);
+
+    // Invoke the HKDF-specific helper function.
+    status = derive_aes_key_hkdf(
+        provider,
+        secret,
+        key_bit_len,
+        hash_alg,
+        hkdf_info,
+        hkdf_info_len,
+        hkdf_salt,
+        hkdf_salt_len,
+        &key
+    );
+    if (FAILED(status))
     {
-        // Define parameters used by KBKDF: the context and label.
-        // Both of these parameters influence the resulting derived key. We want
-        // Alice and Bob (our two parties) to derive the *same* AES key, so we
-        // choose to use constant values here.
-        const wchar_t* kbkdf_context = L"ctx";
-        const size_t kbkdf_context_len = wcslen(kbkdf_context);
-        const wchar_t* kbkdf_label = L"enc,dec";
-        const size_t kbkdf_label_len = wcslen(kbkdf_label);
-        
-        // Invoke the KBKDF-specific helper function.
-        status = derive_aes_key_kbkdf(
-            provider,
-            secret,
-            key_bit_len,
-            hash_alg,
-            kbkdf_context,
-            kbkdf_context_len,
-            kbkdf_label,
-            kbkdf_label_len,
-            &key
-        );
-        if (FAILED(status))
-        {
-            goto cleanup;
-        }
-        
-        // On success, assign the key handle to the return pointer, and reset
-        // `key` back to NULL, to transfer ownership.
-        *result = key;
-        key = NULL;
-        status = S_OK;
+        goto cleanup;
     }
-    else // kdf == KDF_TYPE_HKDF
-    {
-        // Define parameters used by HKDF: the info and salt.
-        // Both of these parameters influence the resulting derived key. We want
-        // Alice and Bob (our two parties) to derive the *same* AES key, so we
-        // choose to use constant values here.
-        const wchar_t* hkdf_info = L"info";
-        const size_t hkdf_info_len = wcslen(hkdf_info);
-        const wchar_t* hkdf_salt = L"salt";
-        const size_t hkdf_salt_len = wcslen(hkdf_salt);
-        
-        // Invoke the HKDF-specific helper function.
-        status = derive_aes_key_hkdf(
-            provider,
-            secret,
-            key_bit_len,
-            hash_alg,
-            hkdf_info,
-            hkdf_info_len,
-            hkdf_salt,
-            hkdf_salt_len,
-            &key
-        );
-        if (FAILED(status))
-        {
-            goto cleanup;
-        }
-        
-        // On success, assign the key handle to the return pointer, and reset
-        // `key` back to 0, to transfer ownership.
-        *result = key;
-        key = NULL;
-        status = S_OK;
-    }
+
+    // On success, assign the key handle to the return pointer, and reset
+    // `key` back to 0, to transfer ownership.
+    *result = key;
+    key = NULL;
+    status = S_OK;
 
 cleanup:
     SECURITY_STATUS exit_status = status;
@@ -718,7 +521,7 @@ static SECURITY_STATUS encrypt_aes_cbc(NCRYPT_KEY_HANDLE key,
     pinfo.pbOtherInfo = NULL;
     pinfo.cbOtherInfo = 0;
     pinfo.dwFlags = 0;
-    
+
     BYTE* ciphertext = NULL;
     DWORD ciphertext_len = 0;
 
@@ -773,7 +576,7 @@ static SECURITY_STATUS encrypt_aes_cbc(NCRYPT_KEY_HANDLE key,
     *result_len = (size_t) ciphertext_len;
     ciphertext = NULL;
     status = S_OK;
-    
+
 cleanup:
     SECURITY_STATUS exit_status = status;
 
@@ -811,7 +614,7 @@ static SECURITY_STATUS decrypt_aes_cbc(NCRYPT_KEY_HANDLE key,
     pinfo.pbOtherInfo = NULL;
     pinfo.cbOtherInfo = 0;
     pinfo.dwFlags = 0;
-    
+
     BYTE* plaintext = NULL;
     DWORD plaintext_len = 0;
 
@@ -866,7 +669,7 @@ static SECURITY_STATUS decrypt_aes_cbc(NCRYPT_KEY_HANDLE key,
     *result_len = (size_t) plaintext_len;
     plaintext = NULL;
     status = S_OK;
-    
+
 cleanup:
     SECURITY_STATUS exit_status = status;
 
@@ -882,44 +685,6 @@ cleanup:
 
 
 // ================================== Main ================================== //
-// Helper function that determines which KDF (Key Derivation Function) to use
-// during execution, based on the command-line arguments provided by the user.
-static KDFType parse_kdf_type(int argc, char** argv)
-{
-    KDFType result = KDF_TYPE_KBKDF;
-    
-    // Iterate through each command-line argument (skipping the first, which is
-    // the executable path) and look for either "KBKDF" or "HKDF". Convert
-    // strings to lowercase to allow for case insensitive matches.
-    for (int i = 1; i < argc; i++)
-    {
-        char* arg = argv[i];
-
-        // Make a copy of the argument string, and convert it to lowercase
-        size_t str_len = std::strlen(arg);
-        char* str = new char[str_len + 1];
-        for (size_t j = 0; j < str_len; j++)
-        {
-            str[j] = std::tolower(static_cast<unsigned char>(arg[j]));
-        }
-        str[str_len] = '\0';
-
-        // Does the string match KBKDF or HKDF? If so, update the return value
-        if (!strcmp(str, "kbkdf"))
-        {
-            result = KDF_TYPE_KBKDF;
-        }
-        else if (!strcmp(str, "hkdf"))
-        {
-            result = KDF_TYPE_HKDF;
-        }
-
-        delete[] str;
-    }
-    
-    return result;
-}
-
 // Main function. Program execution begins and ends here.
 int main(int argc, char** argv)
 {
@@ -928,15 +693,11 @@ int main(int argc, char** argv)
 
     HRESULT status = S_OK;
 
-    // Parse the command-line arguments to determine which of the two
-    // AziHSM-supported KDFs (Key Derivation Functions) to use for the demo.
-    KDFType kdf_type = parse_kdf_type(argc, argv);
-    printf("Keys will be derived using: %s.\n",
-           kdf_type == KDF_TYPE_KBKDF ? "KBKDF" : "HKDF");
+    printf("Keys will be derived using HKDF.\n");
 
     // Define several objects that will be initialized & used below. We define
     // them all at once, in the beginning, so we can use `goto` statements all
-    // throughout this function to jump to the cleanup routine. 
+    // throughout this function to jump to the cleanup routine.
     NCRYPT_PROV_HANDLE provider = NULL;          // <-- AziHSM provider handle
     NCRYPT_KEY_HANDLE p1_ecdh_key = NULL;        // <-- Alice's private ECDH key handle
     NCRYPT_KEY_HANDLE p2_ecdh_key = NULL;        // <-- Bob's private ECDH key handle
@@ -961,7 +722,7 @@ int main(int argc, char** argv)
     BYTE* p2_decrypted = NULL;                   // <-- Bob's AES-decrypted plaintext.
     char* hexstr = NULL;                         // <-- Pointer used for storing hexadecimal strings
     size_t hexstr_len = 0;                       // <-- Length field for `hexstr`
-   
+
     // Start by opening a NCrypt provider handle to the AziHSM
     status = NCryptOpenStorageProvider(&provider, AZIHSM_KSP_NAME, 0);
     if (FAILED(status))
@@ -1007,7 +768,7 @@ int main(int argc, char** argv)
     }
     printf("Generated ECDH key for Bob: 0x%08x\n", (int) p2_ecdh_key);
 
-    
+
     // ---------- Step 2 - Exchanging Secrets with ECDH Key Pairs ----------- //
     printf("\nStep 2: ECDH Secret Exchange"
            "\n----------------------------\n");
@@ -1046,7 +807,7 @@ int main(int argc, char** argv)
     // (the two buffers we just exported), we'll invoke `NCryptImportKey()`
     // twice below, once for each of the keys. These will give us a key handle
     // with which we can use Alice and Bob's public ECDH keys.
-    
+
     // Import the first party's ("Alice") ECDH public key
     status = import_ecdh_key(
         provider,
@@ -1059,7 +820,7 @@ int main(int argc, char** argv)
         goto cleanup;
     }
     printf("Imported Alice's ECDH public key: 0x%08x\n", (int) p1_ecdh_public_key);
-    
+
     // Import the first party's ("Bob") ECDH public key
     status = import_ecdh_key(
         provider,
@@ -1087,7 +848,7 @@ int main(int argc, char** argv)
         goto cleanup;
     }
     printf("Generated Alice's shared secret: 0x%08x\n", (int) p1_secret);
-    
+
     // Use Bob's private key, and Alice's imported public key, to generate a
     // shared secret for Bob.
     status = generate_secret(p2_ecdh_key, p1_ecdh_public_key, &p2_secret);
@@ -1097,32 +858,15 @@ int main(int argc, char** argv)
     }
     printf("Generated Bob's shared secret: 0x%08x\n", (int) p2_secret);
 
-    
-    // ----------- Step 3 - Deriving AES Keys with KBKDF or HKDF ------------ //
-    // This sample can demonstrate AES key derivation using either KBKDF
-    // (Key-Based Key Derivation Function) or HKDF (HMAC-based Key Derivation
-    // Function).
-
-    if (kdf_type == KDF_TYPE_KBKDF)
-    {
-        printf("\nStep 3: KBKDF AES"
-               "\n-----------------\n");
-    }
-    else // kdf_type == KDF_TYPE_HKDF
-    {
-        printf("\nStep 3: HKDF AES"
-               "\n----------------\n");
-    }
+    // --------------------- Step 3 - Deriving AES Keys --------------------- //
+    printf("\nStep 3: HKDF AES"
+           "\n----------------\n");
 
     // Next, the two parties will each derive an AES key from the shared secret
     // that was generated above.
     //
-    // For this sample, we'll use SHA256 as the hashing algorithm, and we'll
-    // choose between KBKDF and HKDF as our key derivation function.  The input
-    // parameters for `NCryptDeriveKey()` differ between the two KDF types; see
-    // the `derive_aes_key()` helper function for the details.
-    //
-    // We will derive an AES key with a length of 256 bits.
+    // For this sample, we'll use SHA256 as the hashing algorithm for the key
+    // derivation. We will derive an AES key with a length of 256 bits.
 
     // Use Alice's shared secret handle to have the AziHSM derive an AES key.
     status = derive_aes_key(
@@ -1130,35 +874,31 @@ int main(int argc, char** argv)
         p1_secret,
         256,
         BCRYPT_SHA256_ALGORITHM,
-        kdf_type,
         &p1_derived_key
     );
     if (FAILED(status))
     {
         goto cleanup;
     }
-    printf("Derived Alice's AES key using %s: 0x%08x\n",
-           kdf_type == KDF_TYPE_KBKDF ? "KBKDF" : "HKDF",
+    printf("Derived Alice's AES key using HKDF: 0x%08x\n",
            (int) p1_derived_key);
-    
+
     // Use Bob's shared secret handle to have the AziHSM derive an AES key.
     status = derive_aes_key(
         provider,
         p2_secret,
         256,
         BCRYPT_SHA256_ALGORITHM,
-        kdf_type,
         &p2_derived_key
     );
     if (FAILED(status))
     {
         goto cleanup;
     }
-    printf("Derived Bob's AES key using %s: 0x%08x\n",
-           kdf_type == KDF_TYPE_KBKDF ? "KBKDF" : "HKDF",
+    printf("Derived Bob's AES key using HKDF: 0x%08x\n",
            (int) p2_derived_key);
-    
-   
+
+
     // ------------ Step 4 - Performing AES-CBC Encrypt/Decrypt ------------- //
     printf("\nStep 4: AES-CBC Encrypt/Decrypt"
            "\n-------------------------------\n");
@@ -1187,7 +927,7 @@ int main(int argc, char** argv)
     // input to `NCryptDecrypt()`, to ensure both parties (Alice, who is
     // encrypting, and Bob, who is decrypting) use the exact same init vector.
     memcpy(iv_copy, iv, sizeof(BYTE) * iv_len);
-    
+
     // Display the plaintext as a hex string:
     if (FAILED(buffer_to_hex(plaintext, plaintext_len, &hexstr, &hexstr_len)))
     {
@@ -1195,7 +935,7 @@ int main(int argc, char** argv)
     }
     printf("Plaintext to be encrypted: [%s]\n", hexstr);
     free(hexstr);
-    
+
     // Display the initialization vector as a hex string:
     if (FAILED(buffer_to_hex(iv, iv_len, &hexstr, &hexstr_len)))
     {
@@ -1203,7 +943,7 @@ int main(int argc, char** argv)
     }
     printf("AES-CBC Initialization Vector: [%s]\n", hexstr);
     free(hexstr);
-    
+
     // Encrypt the plaintext as the first party ("Alice"), using her derived
     // AES key.
     status = encrypt_aes_cbc(
@@ -1215,7 +955,7 @@ int main(int argc, char** argv)
         &p1_ciphertext,
         &p1_ciphertext_len
     );
-    
+
     // Display Alice's ciphertext
     if (FAILED(buffer_to_hex(p1_ciphertext, p1_ciphertext_len, &hexstr, &hexstr_len)))
     {
@@ -1276,7 +1016,7 @@ int main(int argc, char** argv)
     // scenario to exchange a shared secret and use it to set up a secure line
     // of communication between two parties.
 
-    
+
     // -------------------------- Cleanup Routine --------------------------- //
     // Label for cleaning up resources after encountering an error or ending
     // the demo. Frees the NCrypt provider handle and any other live resources.
@@ -1289,7 +1029,7 @@ cleanup:
 
     printf("\nCleaning Up"
            "\n-----------\n");
-    
+
     // Free encrypted/decrypted ciphertext/plaintext buffers:
     if (p2_decrypted != NULL)
     {
@@ -1324,37 +1064,65 @@ cleanup:
         printf("Freed plaintext buffer.\n");
     }
 
-    // Is Bob's derived AES key in use? Free it
+    // Is Bob's derived AES key in use? Delete it and free the handle.
     if (p2_derived_key != NULL)
     {
-        status = NCryptFreeObject(p2_derived_key);
+        status = NCryptDeleteKey(p2_derived_key, 0);
         if (FAILED(status))
         {
-            fprintf(stderr, "Failed to free Bob's derived AES key handle. "
-                    "NCryptFreeObject returned: 0x%08x\n",
+            fprintf(stderr, "Failed to delete Bob's derived AES key. "
+                    "NCryptDeleteKey returned: 0x%08x\n",
                     status);
+
+            // If we failed to delete the key, try to free the key handle.
+            status = NCryptFreeObject(p2_derived_key);
+            if (FAILED(status))
+            {
+                fprintf(stderr, "Failed to free Bob's derived AES key handle during cleanup. "
+                        "NCryptFreeObject returned: 0x%08x\n",
+                        status);
+            }
+            else
+            {
+                p2_derived_key = NULL;
+                printf("Freed Bob's derived AES key handle.\n");
+            }
         }
         else
         {
             p2_derived_key = NULL;
-            printf("Freed Bob's derved AES key handle.\n");
+            printf("Deleted Bob's derived AES key (and freed the key handle).\n");
         }
     }
 
-    // Is Alice's derived AES key in use? Free it
+    // Is Alice's derived AES key in use? Delete it and free the handle.
     if (p1_derived_key != NULL)
     {
-        status = NCryptFreeObject(p1_derived_key);
+        status = NCryptDeleteKey(p1_derived_key, 0);
         if (FAILED(status))
         {
-            fprintf(stderr, "Failed to free Alice's derived AES key handle. "
-                    "NCryptFreeObject returned: 0x%08x\n",
+            fprintf(stderr, "Failed to delete Alice's derived AES key. "
+                    "NCryptDeleteKey returned: 0x%08x\n",
                     status);
+
+            // If we failed to delete the key, try to free the key handle.
+            status = NCryptFreeObject(p1_derived_key);
+            if (FAILED(status))
+            {
+                fprintf(stderr, "Failed to free Alice's derived AES key handle during cleanup. "
+                        "NCryptFreeObject returned: 0x%08x\n",
+                        status);
+            }
+            else
+            {
+                p1_derived_key = NULL;
+                printf("Freed Alice's derived AES key handle.\n");
+            }
         }
         else
         {
             p1_derived_key = NULL;
-            printf("Freed Alice's derved AES key handle.\n");
+            printf("Deleted Alice's derived AES key (and freed the key handle).\n");
         }
     }
 
@@ -1392,37 +1160,67 @@ cleanup:
         }
     }
 
-    // Is Bob's imported ECDH public key still in use? Free it
+    // Is Bob's imported ECDH public key still in use? Delete it and free the
+    // handle.
     if (p2_ecdh_public_key != NULL)
     {
-        status = NCryptFreeObject(p2_ecdh_public_key);
+        status = NCryptDeleteKey(p2_ecdh_public_key, 0);
         if (FAILED(status))
         {
-            fprintf(stderr, "Failed to free Bob's imported ECDH public key handle. "
-                    "NCryptFreeObject returned: 0x%08x\n",
+            fprintf(stderr, "Failed to delete Bob's imported ECDH public key. "
+                    "NCryptDeleteKey returned: 0x%08x\n",
                     status);
+
+            // If we failed to delete the key, try to free the key handle.
+            status = NCryptFreeObject(p2_ecdh_public_key);
+            if (FAILED(status))
+            {
+                fprintf(stderr, "Failed to free Bob's imported ECDH public key handle during cleanup. "
+                        "NCryptFreeObject returned: 0x%08x\n",
+                        status);
+            }
+            else
+            {
+                p2_ecdh_public_key = NULL;
+                printf("Freed Bob's imported ECDH public key handle.\n");
+            }
         }
         else
         {
             p2_ecdh_public_key = NULL;
-            printf("Freed Bob's imported ECDH public key handle.\n");
+            printf("Deleted Bob's imported ECDH public key (and freed the key handle).\n");
         }
     }
 
-    // Is Alice's imported ECDH public key still in use? Free it
+    // Is Alice's imported ECDH public key still in use? Delete it and free the
+    // handle.
     if (p1_ecdh_public_key != NULL)
     {
-        status = NCryptFreeObject(p1_ecdh_public_key);
+        status = NCryptDeleteKey(p1_ecdh_public_key, 0);
         if (FAILED(status))
         {
-            fprintf(stderr, "Failed to free Alice's imported ECDH public key handle. "
-                    "NCryptFreeObject returned: 0x%08x\n",
+            fprintf(stderr, "Failed to delete Alice's imported ECDH public key. "
+                    "NCryptDeleteKey returned: 0x%08x\n",
                     status);
+
+            // If we failed to delete the key, try to free the key handle.
+            status = NCryptFreeObject(p1_ecdh_public_key);
+            if (FAILED(status))
+            {
+                fprintf(stderr, "Failed to free Alice's imported ECDH public key handle during cleanup. "
+                        "NCryptFreeObject returned: 0x%08x\n",
+                        status);
+            }
+            else
+            {
+                p1_ecdh_public_key = NULL;
+                printf("Freed Alice's imported ECDH public key handle.\n");
+            }
         }
         else
         {
             p1_ecdh_public_key = NULL;
-            printf("Freed Alice's imported ECDH public key handle.\n");
+            printf("Deleted Alice's imported ECDH public key (and freed the key handle).\n");
         }
     }
 
@@ -1440,37 +1238,67 @@ cleanup:
         printf("Freed Alice's exported ECDH public key data buffer.\n");
     }
 
-    // Is Bob's ECDH key handle still in use at this point? If so, free it.
+    // Is Bob's ECDH key handle still in use at this point? If so, delete it
+    // and free the handle.
     if (p2_ecdh_key != NULL)
     {
-        status = NCryptFreeObject(p2_ecdh_key);
+        status = NCryptDeleteKey(p2_ecdh_key, 0);
         if (FAILED(status))
         {
-            fprintf(stderr, "Failed to free Bob's ECDH key handle. "
-                    "NCryptFreeObject returned: 0x%08x\n",
+            fprintf(stderr, "Failed to delete Bob's ECDH key. "
+                    "NCryptDeleteKey returned: 0x%08x\n",
                     status);
+
+            // If we failed to delete the key, try to free the key handle.
+            status = NCryptFreeObject(p2_ecdh_key);
+            if (FAILED(status))
+            {
+                fprintf(stderr, "Failed to free Bob's ECDH key handle during cleanup. "
+                        "NCryptFreeObject returned: 0x%08x\n",
+                        status);
+            }
+            else
+            {
+                p2_ecdh_key = NULL;
+                printf("Freed Bob's ECDH key handle.\n");
+            }
         }
         else
         {
             p2_ecdh_key = NULL;
-            printf("Freed Bob's ECDH key handle.\n");
+            printf("Deleted Bob's ECDH key (and freed the key handle).\n");
         }
     }
 
-    // Is Alice's ECDH key handle still in use at this point? If so, free it.
+    // Is Alice's ECDH key handle still in use at this point? If so, delete it
+    // and free the handle.
     if (p1_ecdh_key != NULL)
     {
-        status = NCryptFreeObject(p1_ecdh_key);
+        status = NCryptDeleteKey(p1_ecdh_key, 0);
         if (FAILED(status))
         {
-            fprintf(stderr, "Failed to free Alice's ECDH key handle. "
-                    "NCryptFreeObject returned: 0x%08x\n",
+            fprintf(stderr, "Failed to delete Alice's ECDH key. "
+                    "NCryptDeleteKey returned: 0x%08x\n",
                     status);
+
+            // If we failed to delete the key, try to free the key handle.
+            status = NCryptFreeObject(p1_ecdh_key);
+            if (FAILED(status))
+            {
+                fprintf(stderr, "Failed to free Alice's ECDH key handle during cleanup. "
+                        "NCryptFreeObject returned: 0x%08x\n",
+                        status);
+            }
+            else
+            {
+                p1_ecdh_key = NULL;
+                printf("Freed Alice's ECDH key handle.\n");
+            }
         }
         else
         {
             p1_ecdh_key = NULL;
-            printf("Freed Alice's ECDH key handle.\n");
+            printf("Deleted Alice's ECDH key (and freed the key handle).\n");
         }
     }
 

--- a/samples/cpp/ECDH-KDF-AESCBC/README.md
+++ b/samples/cpp/ECDH-KDF-AESCBC/README.md
@@ -5,10 +5,8 @@ This sample demonstrates the AziHSM in the following scenario:
 
 1. Generate two ECDH public/private key pairs. (Each key pair represents a separate party: "Alice" (party 1) and "Bob" (party 2))
 2. Perform ECDH key exchange, to exchange public keys between the two parties, and generate a shared secret.
-3. Use KBKDF or HKDF to derive the same AES key (using the shared secret) for both parties.
-    * KBKDF ("Key Based Key Derivation Function") refers to the **SP800-108 HMAC in counter mode** KDF, as seen [here](https://learn.microsoft.com/en-us/windows/win32/api/bcrypt/nf-bcrypt-bcryptkeyderivation) in the NCrypt API documentation.
+3. Use HKDF to derive the same AES key (using the shared secret) for both parties.
     * HKDF ("HMAC-based Key Derivation Function") is defined in [IETF RFC 5869](https://datatracker.ietf.org/doc/html/rfc5869), and is referred to in NCrypt by the `BCRYPT_HKDF_ALGORITHM` string.
-    * **NOTE:** The user can choose between demonstrating KBKDF or HKDF via a command-line argument.
 4. Perform AES-CBC encryption and decryption to verify that the two derived AES keys are identical.
 
 This scenario shows one way to utilize the AziHSM to establish a secure communication channel between two parties.
@@ -37,18 +35,10 @@ This will populate Visual Studio with the sample project's contents.
 Build and run the project with `F5`, or by selecting `Build > Build Solution`.
 An executable will be produced within the project directory, which can be executed on the Windows command-line (PowerShell or Command Prompt).
 
-The sample accepts a single command-line argument, which is used to choose between the two KDFs (Key Derivation Functions) supported by AziHSM: KBKDF and HKDF.
-Run the executable in one of the following ways:
+The executable requires no command-line input; simply execute it like so:
 
 ```powershell
-# Provide NO argument to choose KBKDF by default:
 .\ECDH-KDF-AESCBC.exe
-
-# To select KBKDF:
-.\ECDH-KDF-AESCBC.exe KBKDF
-
-# To select HKDF:
-.\ECDH-KDF-AESCBC.exe HKDF
 ```
 
 You should see output similar to this:
@@ -59,33 +49,34 @@ You should see output similar to this:
 ```
 AziHSM Demonstration: ECDH Generate --> ECDH Exchange --> KDF AES --> AES-CBC Enc/Dec
 =====================================================================================
-Opened NCrypt Storage Provider handle: 0xbce1ce80
+Keys will be derived using HKDF.
+Opened NCrypt Storage Provider handle: 0xb9f1dd50
 
-Step 1: ECHD Key Pair Generate
+Step 1: ECDH Key Pair Generate
 ------------------------------
-Generated ECDH key for Alice: 0xbce2a9e0
-Generated ECDH key for Bob: 0xbce2a6a0
+Generated ECDH key for Alice: 0xb9f325b0
+Generated ECDH key for Bob: 0xb9f31cf0
 
 Step 2: ECDH Secret Exchange
 ----------------------------
 Exported Alice's ECDH public key: 72 bytes of data
 Exported Bob's ECDH public key: 72 bytes of data
-Imported Alice's ECDH public key: 0xbce29be0
-Imported Bob's ECDH public key: 0xbce29e60
-Generated Alice's shared secret: 0xbce237b0
-Generated Bob's shared secret: 0xbce237d0
+Imported Alice's ECDH public key: 0xb9f32570
+Imported Bob's ECDH public key: 0xb9f31a30
+Generated Alice's shared secret: 0xb9f2c9f0
+Generated Bob's shared secret: 0xb9f2c9b0
 
-Step 3: KBKDF AES
------------------
-Derived Alice's AES key: 0xbce2a5a0
-Derived Bob's AES key: 0xbce2a320
+Step 3: HKDF AES
+----------------
+Derived Alice's AES key using HKDF: 0xb9f31b70
+Derived Bob's AES key using HKDF: 0xb9f325f0
 
 Step 4: AES-CBC Encrypt/Decrypt
 -------------------------------
-Plaintext to be encrypted: [c8 90 a5 48 4e 89 48 6d cf 8a 4f 95 7a 0a 59 ec 54 e9 ef c9 cf f4 9a 1c 5b 28 af 8c 1e 8f fd 82 fb b3 4c d6 59 3c e3 86 40 5f b6 95 9d d2 b5 ac 5e 28 45 6c 3f 0a f2 6d 0a bf c9 20 08 fd 53 62 5e 36 d1 a8 4e fa 79 67 8f 06 3d 37 ec e3 7b 91 40 3b ff 7e 05 61 b4 dc 88 8b 6b 93 a3 f6 fd 47 3a 01 7e 37 2a bd 0f e4 59 eb b6 a2 e5 ec b4 19 91 4e 9a 84 24 3c 96 bd 04 03 b9 68 3c c7 17 9d]
-AES-CBC Initialization Vector: [e7 e4 b3 e0 4b 73 9f 71 ca 68 4c b1 e0 fd 0d b4]
-Encrypted plaintext with Alice's AES key: [d0 2e a1 6a 30 e9 0d fd 83 29 6b fc 4a e6 f4 a1 6d 38 03 cc 57 5d 2f a5 f9 87 ce bc 83 81 86 6f b1 d1 1d 77 fc 39 92 a3 ea 40 1a fb a1 e3 8c ce c7 f7 82 83 47 bf ed b3 01 fc be 4c 50 dc 7c 26 25 65 5b 1e c9 f0 89 38 a2 b8 0f 76 11 cb f0 00 9b bf 8f 6b d9 9c 10 cb 74 79 3c a3 bc 09 00 03 80 ce 8e 88 87 ef da 5d 93 44 36 df 74 87 80 cd e3 4c ec 25 12 cb c2 cf e3 1c 34 85 9d b8 64 d6]
-Decrypted ciphertext with Bob's AES key: [c8 90 a5 48 4e 89 48 6d cf 8a 4f 95 7a 0a 59 ec 54 e9 ef c9 cf f4 9a 1c 5b 28 af 8c 1e 8f fd 82 fb b3 4c d6 59 3c e3 86 40 5f b6 95 9d d2 b5 ac 5e 28 45 6c 3f 0a f2 6d 0a bf c9 20 08 fd 53 62 5e 36 d1 a8 4e fa 79 67 8f 06 3d 37 ec e3 7b 91 40 3b ff 7e 05 61 b4 dc 88 8b 6b 93 a3 f6 fd 47 3a 01 7e 37 2a bd 0f e4 59 eb b6 a2 e5 ec b4 19 91 4e 9a 84 24 3c 96 bd 04 03 b9 68 3c c7 17 9d]
+Plaintext to be encrypted: [bb e4 27 5f ce f0 04 5b 15 7e ab ba 8a bc 47 07 5b 0a 0c d1 6a e7 d3 a6 e8 77 13 13 3e a2 9f 6b b6 5e 77 96 26 63 fe 7f 72 2c 11 13 20 6d 8d e5 3b cb 2e 2e c6 05 56 0e f2 cf 4c 5b 8e 95 08 5b de 7a 21 1e dc d2 82 e4 8c e3 b2 cf 1a f8 1e c0 94 f9 6c 0a 57 5b 70 45 93 cd 66 9e 4a d2 00 4e 51 a4 05 32 88 4d e5 99 d8 90 57 07 71 8c db 41 1d 5a b1 26 f4 c6 58 3e d4 6c a6 de 47 09 7e 5e]
+AES-CBC Initialization Vector: [1a cd 7c 08 e1 33 86 de 09 4e ed b0 92 1c 16 3b]
+Encrypted plaintext with Alice's AES key: [c0 90 9e 76 7a 5f a7 5e 39 2a da 4c c6 bf ad 4c 7b 97 11 ec 4d 93 bd 34 8c c5 d8 3a 46 75 c2 a9 55 4d 4c b0 b1 bc 5b ee 56 16 64 e1 29 5b bb a0 18 03 1e 97 e9 6b 47 74 48 52 3f 8d ae 63 26 92 18 0a 53 fe 07 0e 56 49 c3 18 06 74 43 91 b2 9b 73 06 c4 6d 3b c8 35 b0 f2 17 3d c4 96 9b 50 31 63 cd 57 ef e7 fe c8 f5 19 d2 2d 32 50 0f 50 13 79 28 57 69 98 4e c4 28 6d 1b a4 25 a4 49 5a 4c]
+Decrypted ciphertext with Bob's AES key: [bb e4 27 5f ce f0 04 5b 15 7e ab ba 8a bc 47 07 5b 0a 0c d1 6a e7 d3 a6 e8 77 13 13 3e a2 9f 6b b6 5e 77 96 26 63 fe 7f 72 2c 11 13 20 6d 8d e5 3b cb 2e 2e c6 05 56 0e f2 cf 4c 5b 8e 95 08 5b de 7a 21 1e dc d2 82 e4 8c e3 b2 cf 1a f8 1e c0 94 f9 6c 0a 57 5b 70 45 93 cd 66 9e 4a d2 00 4e 51 a4 05 32 88 4d e5 99 d8 90 57 07 71 8c db 41 1d 5a b1 26 f4 c6 58 3e d4 6c a6 de 47 09 7e 5e]
 The decrypted ciphertext matches the original plaintext!
 
 Cleaning Up

--- a/samples/cpp/QUERY-PROPERTIES/QUERY-PROPERTIES/QUERY-PROPERTIES.cpp
+++ b/samples/cpp/QUERY-PROPERTIES/QUERY-PROPERTIES/QUERY-PROPERTIES.cpp
@@ -3,10 +3,9 @@
 
 // This sample demonstrates querying the properties that AziHSM exposes to user:
 //
-// 1. "AZIHSM_DEVICE_CERT_CHAIN_PROPERTY"
-// 2. "AZIHSM_DEVICE_MAX_STORAGE_SIZE_PROPERTY"
-// 3. "AZIHSM_DEVICE_MAX_KEY_COUNT_PROPERTY"
-// 
+// 1. "AZIHSM_DEVICE_MAX_STORAGE_SIZE_PROPERTY"
+// 2. "AZIHSM_DEVICE_MAX_KEY_COUNT_PROPERTY"
+//
 // For detailed explanation of each property, please refer to related demo below.
 //
 //
@@ -70,36 +69,6 @@ cleanup:
     return status;
 }
 
-// Query "AZIHSM_DEVICE_CERT_CHAIN_PROPERTY"
-// You can retrieve the device certificate chain with this property.
-// The returned buffer will contain multiple certificates in PEM format, concatenated together with newline (\n).
-// The leaf certificate will be first in the chain.
-// Retrieving this property is useful during device attestation, for more information about attestation,
-// see another sample: ATTEST-UNWRAP-RSA
-static SECURITY_STATUS queryCertChainProperty(NCRYPT_PROV_HANDLE provider) {
-    SECURITY_STATUS status = E_FAIL;
-
-    PBYTE buffer = NULL;
-    DWORD bufferSize;
-
-    status = query(provider, AZIHSM_PROPERTY_CERT_CHAIN_NAME, &buffer, &bufferSize);
-    if (FAILED(status))
-    {
-        fprintf(stderr, "Failed to get AZIHSM_PROPERTY_CERT_CHAIN_NAME. query returned: 0x%08x\n", status);
-        goto cleanup;
-    }
-
-    // To not flood the console with the certificate chain, we will not print it here.
-    printf("Retrieved AZIHSM_DEVICE_CERT_CHAIN_PROPERTY successfully. Buffer size: %lu\n", bufferSize);
-
-    status = S_OK;
-cleanup:
-    if (buffer)
-    {
-        delete[] buffer;
-    }
-    return status;
-}
 
 // Query "AZIHSM_DEVICE_MAX_STORAGE_SIZE_PROPERTY"
 // You can retrieve the maximum storage size of the AziHSM device.
@@ -156,7 +125,7 @@ cleanup:
 // You can retrieve the maximum number of keys that can be stored on the AziHSM device at the same time.
 // The returned buffer should have 4 bytes, which is the little-endian representation of a 32-bit unsigned integer
 // The integer represents the maximum number of keys that can be stored.
-// Note: 
+// Note:
 //   1. It's not reflecting real-time key count left.
 //   2. Actual number of keys may be lower if storage runs out first.
 //   3. Built-in keys (like AZIHSM_BUILTIN_UNWRAP_KEY) will share the allocation.
@@ -224,17 +193,6 @@ int main() {
         goto cleanup;
     }
     printf("Opened NCrypt Storage Provider handle: 0x%08x\n", (int) provider);
-
-    printf("\nQuery AZIHSM_DEVICE_CERT_CHAIN_PROPERTY"
-           "\n---------------------------------------\n");
-    status = queryCertChainProperty(provider);
-    if (FAILED(status))
-    {
-        fprintf(stderr,
-            "Failed to query AZIHSM_DEVICE_CERT_CHAIN_PROPERTY: 0x%08x\n",
-            status);
-        goto cleanup;
-    }
 
     printf("\nQuery AZIHSM_DEVICE_MAX_STORAGE_SIZE_PROPERTY"
            "\n---------------------------------------------\n");

--- a/samples/cpp/QUERY-PROPERTIES/README.md
+++ b/samples/cpp/QUERY-PROPERTIES/README.md
@@ -6,8 +6,7 @@ This sample demonstrates querying of the following properties that AziHSM expose
 
 | Property (string)                       | Description                                              | Content                                                                 |
 |-----------------------------------------|----------------------------------------------------------|-------------------------------------------------------------------------|
-| AZIHSM_DEVICE_CERT_CHAIN_PROPERTY       | Certificate chain of the device. Useful for attestation. | List of certificates in PEM format, separated by `\n`. Leaf cert first. |
-| AZIHSM_DEVICE_MAX_STORAGE_SIZE_PROPERTY | Maximum storage capacity of the device, in Kilo Bytes.       | 4 bytes buffer holding unsigned 32-bit integer. Little Endian.          |
+| AZIHSM_DEVICE_MAX_STORAGE_SIZE_PROPERTY | Maximum storage capacity of the device, in Kilo Bytes.   | 4 bytes buffer holding unsigned 32-bit integer. Little Endian.          |
 | AZIHSM_DEVICE_MAX_KEY_COUNT_PROPERTY    | Maximum number of keys can be stored on the device.      | 4 bytes buffer holding unsigned 32-bit integer. Little Endian.          |
 
 There are other properties that are tied to keys:
@@ -49,10 +48,6 @@ AziHSM Demonstration: Querying properties
 Open AziHSM Provider
 --------------------
 Opened NCrypt Storage Provider handle: 0x0fee6ac0
-
-Query AZIHSM_DEVICE_CERT_CHAIN_PROPERTY
----------------------------------------
-Retrieved AZIHSM_DEVICE_CERT_CHAIN_PROPERTY successfully. Buffer size: 619
 
 Query AZIHSM_DEVICE_MAX_STORAGE_SIZE_PROPERTY
 ---------------------------------------------

--- a/samples/cpp/RSA-IMPORT-ENCRYPT-DECRYPT/RSA-IMPORT-ENCRYPT-DECRYPT/RSA-IMPORT-ENCRYPT-DECRYPT.cpp
+++ b/samples/cpp/RSA-IMPORT-ENCRYPT-DECRYPT/RSA-IMPORT-ENCRYPT-DECRYPT/RSA-IMPORT-ENCRYPT-DECRYPT.cpp
@@ -99,7 +99,7 @@ static SECURITY_STATUS open_unwrap_key(NCRYPT_PROV_HANDLE provider,
                 status);
         goto cleanup;
     }
-    
+
     // Set return pointer and a successful status code
     *result = unwrap_key;
     unwrap_key = NULL;
@@ -129,7 +129,7 @@ static SECURITY_STATUS wrap_rsa_key(NCRYPT_PROV_HANDLE provider,
                                     DWORD* result_len)
 {
     SECURITY_STATUS status = S_OK;
-    
+
     BYTE* rsa_private_key_data = NULL;
     DWORD rsa_private_key_data_len = 0;
     DWORD unwrap_key_data_len_max = 600;
@@ -162,7 +162,7 @@ static SECURITY_STATUS wrap_rsa_key(NCRYPT_PROV_HANDLE provider,
                 status);
         goto cleanup;
     }
-    
+
     // ---------------------- Wrapped Blob Generation ----------------------- //
     // The next step is to use the built-in unwrap key's data (and an AES key
     // that we will randomly generate) to create a key blob. This is the blob
@@ -237,7 +237,7 @@ static SECURITY_STATUS import_key_blob(NCRYPT_PROV_HANDLE provider,
     param_buffers[0].cbBuffer = static_cast<ULONG>(wcslen(BCRYPT_RSA_ALGORITHM) + 1) * sizeof(WCHAR);
     param_buffers[0].BufferType = NCRYPTBUFFER_PKCS_ALG_ID;
     param_buffers[0].pvBuffer = (PVOID) BCRYPT_RSA_ALGORITHM;
-    
+
     // Pack the buffer into an `NCryptBufferDesc` object, which we'll pass
     // into `NCryptImportKey`.
     NCryptBufferDesc params;
@@ -265,7 +265,7 @@ static SECURITY_STATUS import_key_blob(NCRYPT_PROV_HANDLE provider,
                 status);
         goto cleanup;
     }
-    
+
     // Set the key's usage with the provided flag.
     status = NCryptSetProperty(
         key,
@@ -319,23 +319,36 @@ static SECURITY_STATUS import_key_blob(NCRYPT_PROV_HANDLE provider,
                 status);
         goto cleanup;
     }
-    
+
     *result = key;
     key = NULL;
     status = S_OK;
 cleanup:
     SECURITY_STATUS exit_status = status;
-    
+
     // If the key handle was never transferred to the return parameter,
-    // something went wrong; free it here
+    // something went wrong; delete it and free the handle
     if (key != NULL)
     {
-        status = NCryptFreeObject(key);
+        status = NCryptDeleteKey(key, 0);
         if (FAILED(status))
         {
-            fprintf(stderr, "Failed to free imported key handle after error. "
-                    "NCryptFreeObject returned: 0x%08x\n",
+            fprintf(stderr, "Failed to delete imported key after error. "
+                    "NCryptDeleteKey returned: 0x%08x\n",
                     status);
+
+            // If we failed to delete the key, try to free the key handle.
+            status = NCryptFreeObject(key);
+            if (FAILED(status))
+            {
+                fprintf(stderr, "Failed to free imported key handle during cleanup. "
+                        "NCryptFreeObject returned: 0x%08x\n",
+                        status);
+            }
+            else
+            {
+                key = NULL;
+            }
         }
         else
         {
@@ -392,7 +405,7 @@ static SECURITY_STATUS encrypt(NCRYPT_KEY_HANDLE key,
                 status);
         goto cleanup;
     }
-    
+
     // Allocate a buffer to store the ciphertext, then call `NCryptEncrypt` a
     // second time to generate it and store the result.
     ciphertext = new BYTE[ciphertext_len];
@@ -413,7 +426,7 @@ static SECURITY_STATUS encrypt(NCRYPT_KEY_HANDLE key,
                 status);
         goto cleanup;
     }
-    
+
     // Set return pointers and a success exit status
     *result = ciphertext;
     *result_len = ciphertext_len;
@@ -481,7 +494,7 @@ static SECURITY_STATUS decrypt(NCRYPT_KEY_HANDLE key,
                 status);
         goto cleanup;
     }
-    
+
     // Allocate a buffer to store the plaintext, then call `NCryptDecrypt` a
     // second time to generate it and store the result.
     decrypted = new BYTE[decrypted_len];
@@ -502,7 +515,7 @@ static SECURITY_STATUS decrypt(NCRYPT_KEY_HANDLE key,
                 status);
         goto cleanup;
     }
-    
+
     // Set return pointers and a success exit status
     *result = decrypted;
     *result_len = decrypted_len;
@@ -561,7 +574,7 @@ static RsaKeyLength parse_key_len(int argc, char** argv)
 
         delete[] str;
     }
-    
+
     return result;
 }
 
@@ -589,7 +602,7 @@ int main(int argc, char** argv)
             fprintf(stderr, "Unexpected RSA key length provided.\n");
             return E_FAIL;
     }
-    
+
     // Define several variables used throughout the main function.
     NCRYPT_PROV_HANDLE provider = NULL;                 // <-- AziHSM KSP handle
     NCRYPT_KEY_HANDLE unwrap_key = NULL;                // <-- Built-in unwrap key handle
@@ -609,7 +622,7 @@ int main(int argc, char** argv)
     const wchar_t* oaep_label = L"labeldata";           // <-- Data used for OAEP padding for RSA encrypt/decrypt
     const size_t oaep_label_len = wcslen(oaep_label);   // Length of the OAEP padding label string
     LPCWSTR oaep_alg = NCRYPT_SHA256_ALGORITHM;         // <-- Hashing algorithm to use for OAEP padding
-    
+
     // Open a handle to the AziHSM via the NCrypt API.
     status = NCryptOpenStorageProvider(&provider, AZIHSM_KSP_NAME, 0);
     if (FAILED(status))
@@ -621,7 +634,7 @@ int main(int argc, char** argv)
     }
     printf("Opened NCrypt Storage Provider handle: 0x%08x\n", (int) provider);
 
-    
+
     // -------------------- Step 1 - Import the RSA Key --------------------- //
     printf("\nStep 1: Import RSA Key"
            "\n----------------------\n");
@@ -659,7 +672,7 @@ int main(int argc, char** argv)
     }
     printf("Created wrapped RSA key blob: %d bytes of data.\n",
            blob_data_len);
-    
+
     // Next, take the blob and import into the AziHSM as an RSA key.
     status = import_key_blob(
         provider,
@@ -676,7 +689,7 @@ int main(int argc, char** argv)
     printf("Successfully imported key into AziHSM. Got handle: 0x%08x.\n",
            (int) imported_key);
 
-    
+
     // --------------- Step 2 - Generate & Encrypt Plaintext ---------------- //
     printf("\nStep 2: Encrypt Plaintext"
            "\n-------------------------\n");
@@ -728,8 +741,8 @@ int main(int argc, char** argv)
     }
     printf("Ciphertext: [%s]\n", hexstr);
     free(hexstr);
-    
-    
+
+
     // ------------------ Step 3 - Decrypt the Ciphertext ------------------- //
     printf("\nStep 3: Decrypt Ciphertext"
            "\n--------------------------\n");
@@ -804,7 +817,7 @@ cleanup:
         decrypted_len = 0;
         printf("Freed decrypted ciphertext buffer.\n");
     }
-    
+
     // Free the ciphertext buffer
     if (ciphertext != NULL)
     {
@@ -813,7 +826,7 @@ cleanup:
         ciphertext_len = 0;
         printf("Freed ciphertext buffer.\n");
     }
-    
+
     // Free the plaintext buffer
     if (plaintext != NULL)
     {
@@ -822,20 +835,34 @@ cleanup:
         plaintext_len = 0;
         printf("Freed plaintext buffer.\n");
     }
-    
-    // Free the handle to the imported RSA key
+
+    // Delete the imported RSA key and free its handle
     if (imported_key != NULL)
     {
-        status = NCryptFreeObject(imported_key);
+        status = NCryptDeleteKey(imported_key, 0);
         if (FAILED(status))
         {
-            fprintf(stderr, "Failed to free imported key handle. "
-                    "NCryptFreeObject returned: 0x%08x\n",
+            fprintf(stderr, "Failed to delete imported key. "
+                    "NCryptDeleteKey returned: 0x%08x\n",
                     status);
+
+            // If we failed to delete the key, try to free the key handle.
+            status = NCryptFreeObject(imported_key);
+            if (FAILED(status))
+            {
+                fprintf(stderr, "Failed to free imported key handle during cleanup. "
+                        "NCryptFreeObject returned: 0x%08x\n",
+                        status);
+            }
+            else
+            {
+                printf("Freed imported key handle.\n");
+                imported_key = NULL;
+            }
         }
         else
         {
-            printf("Freed imported key handle.\n");
+            printf("Deleted imported key (and freed the key handle).\n");
             imported_key = NULL;
         }
     }
@@ -849,7 +876,8 @@ cleanup:
         printf("Freed wrapped key blob data.\n");
     }
 
-    // Free the handle to the AziHSM built-in unwrapping key
+    // Free our handle to the AziHSM import key (built-in unwrapping key); we
+    // do not need to delete this key.
     if (unwrap_key != NULL)
     {
         status = NCryptFreeObject(unwrap_key);

--- a/samples/cpp/include/AziHSM/AziHSM.h
+++ b/samples/cpp/include/AziHSM/AziHSM.h
@@ -144,7 +144,7 @@ inline AZIHSM_STATUS azihsm_parse_claim(
     DWORD* outBufferQuoteSize,
     DWORD* outBufferCertificateOffset,
     DWORD* outBufferCertificateSize) {
-    size_t headerSize = sizeof(AziHSMClaimHeader);
+    DWORD headerSize = (DWORD) sizeof(AziHSMClaimHeader);
 
     if (bufferClaimSize < headerSize)
     {


### PR DESCRIPTION
This PR updates a few of the AziHSM C++ sample applications:

* KBKDF (Key Based Key Derivation Function) is no longer supported, and the appropriate code & docs have been removed from the samples.
* Code for key deletion and key handle freeing has been updated to follow this strategy:
    1. Attempt to delete a key with `NCryptDeleteKey()`
    2. If this fails, attempt to free the key handle with `NCryptFreeObject()`
* Removed the `AZIHSM_DEVICE_CERT_CHAIN_PROPERTY` property from the QUERY-PROPERTIES sample
* Cleaned up extra whitespace
* Fixed a few small compiler warnings in `include/AziHSM.h`