### PR TITLE
Documentation Updates & Tracing Script Level Filtering

### DIFF
--- a/arm_templates/template-azihsm-tvm.json
+++ b/arm_templates/template-azihsm-tvm.json
@@ -129,6 +129,18 @@
         "offer": "windowsserver",
         "sku": "2025-datacenter-smalldisk-g2",
         "version": "latest"
+      },
+      "Ubuntu 2204": {
+        "publisher": "Canonical",
+        "offer": "0001-com-ubuntu-server-jammy",
+        "sku": "22_04-lts-gen2",
+        "version": "latest"
+      },
+      "Azure Linux 3 Gen 2": {
+        "publisher": "MicrosoftCBLMariner",
+        "offer": "azure-linux-3",
+        "sku": "azure-linux-3-gen2",
+        "version": "latest"
       }
     },
     "imageReference": "[variables('imageList')[parameters('osImageName')]]",
@@ -142,6 +154,18 @@
     "subnetName": "[concat(parameters('vmName'), '-sub')]",
     "subnetRefNew": "[concat(variables('virtualNetworkId'), '/subnets/', variables('subnetName'))]",
     "subnetRef": "[if(equals(parameters('vnetNewOrExisting'), 'new'), variables('subnetRefNew'), variables('subnetRefExisting'))]",
+    "isWindows": "[contains(parameters('osImageName'), 'Windows')]",
+    "linuxConfiguration": {
+      "disablePasswordAuthentication": "true",
+      "ssh": {
+        "publicKeys": [
+          {
+            "keyData": "[parameters('adminPasswordOrKey')]",
+            "path": "[concat('/home/', parameters('adminUsername'), '/.ssh/authorized_keys')]"
+          }
+        ]
+      }
+    },
     "windowsConfiguration": {
       "enableAutomaticUpdates": "true",
       "provisionVmAgent": "true"
@@ -260,7 +284,8 @@
           "computerName": "[parameters('vmName')]",
           "adminUsername": "[parameters('adminUsername')]",
           "adminPassword": "[parameters('adminPasswordOrKey')]",
-          "windowsConfiguration": "[variables('windowsConfiguration')]"
+          "linuxConfiguration": "[if(equals(parameters('authenticationType'), 'password'), json('null'), variables('linuxConfiguration'))]",
+          "windowsConfiguration": "[if(variables('isWindows'), variables('windowsConfiguration'), json('null'))]"
         },
         "securityProfile": {
           "uefiSettings": {

--- a/docs/EventTracing.md
+++ b/docs/EventTracing.md
@@ -16,8 +16,8 @@ To begin a trace session, execute the [`trace-collect-start.ps1`](../scripts/tra
 We recommend creating a different trace session for each component:
 
 ```powershell
-.\trace-collect-start.ps1 -SessionName "AZIHSM_DRIVER_TRACE_1" -ProviderGUIDs "6f3170cd-d4f0-4e06-8e07-5bcf2f20771c" -OutputPath "$env:USERPROFILE\AZIHSM_DRIVER_TRACE_1.etl"
-.\trace-collect-start.ps1 -SessionName "AZIHSM_KSP_TRACE_1" -ProviderGUIDs "6f3b7e7a-7f98-4fb5-a0ce-e994136df3e2" -OutputPath "$env:USERPROFILE\AZIHSM_KSP_TRACE_1.etl"
+.\trace-collect-start.ps1 -SessionName "AZIHSM_DRIVER_TRACE_1" -ProviderGUIDs "6f3170cd-d4f0-4e06-8e07-5bcf2f20771c" -OutputPath "$env:USERPROFILE\AZIHSM_DRIVER_TRACE_1.etl" -Level "INFO"
+.\trace-collect-start.ps1 -SessionName "AZIHSM_KSP_TRACE_1" -ProviderGUIDs "6f3b7e7a-7f98-4fb5-a0ce-e994136df3e2" -OutputPath "$env:USERPROFILE\AZIHSM_KSP_TRACE_1.etl" -Level "INFO"
 ```
 
 Upon completion of the script, the output `.etl` file should be created.
@@ -36,6 +36,21 @@ $env:AZIHSMKSP_LOG_LEVEL = "DEBUG"
 # Set back to default
 $env:AZIHSMKSP_LOG_LEVEL = $null
 $env:AZIHSMKSP_LOG_LEVEL = "INFO"
+```
+
+Additionally, you can filter logs at the script level by providing the `-Level` command-line argument:
+
+```powershell
+# Capture only ERROR messages
+.\trace-collect-start.ps1 -Level "ERROR # ..."
+# Capture WARN, ERROR messages
+.\trace-collect-start.ps1 -Level "WARN # ..."
+# Capture INFO, WARN, ERROR messages
+.\trace-collect-start.ps1 -Level "INFO # ..."
+# Capture DEBUG, INFO, WARN, ERROR messages
+.\trace-collect-start.ps1 -Level "DEBUG # ..."
+# Capture TRACE, DEBUG, INFO, WARN, ERROR messages
+.\trace-collect-start.ps1 -Level "TRACE # ..."
 ```
 
 ## Step 2 - Reproduce the Issue

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,19 +1,43 @@
 # AziHSM FAQ
 
-## Q: How do I install the AziHSM?
+## Q: What cryptographic operations, keys, etc., are supported by AziHSM?
 
-You may install the AziHSM dependencies onto your VM by following the steps in our [install guide](./Install.md).
+Please see the [supported algorithms page](./SupportedAlgorithms.md) for a list of the crypto algorithms supported by AziHSM.
 
-## Q: How do I uninstall the AziHSM?
+## Q: What Azure VM SKUs support AziHSM?
 
-You may remove the AziHSM dependencies from your VM by following the steps in our [install guide](./Install.md).
+Please see the [supported SKUs page](./SupportedSKUs.md) for information on the Azure VM SKUs that support AziHSM.
+
+## Q: How do I install the AziHSM guest stack?
+
+You may install the AziHSM dependencies onto your VM by following the steps in our install guides:
+
+* [Windows Install](./InstallWindows.md)
+* [Linux Install](./InstallLinux.md)
+
+## Q: How do I uninstall the AziHSM guest stack?
+
+You may remove the AziHSM dependencies from your VM by following the steps in our install guides:
+
+* [Windows Install](./InstallWindows.md)
+* [Linux Install](./InstallLinux.md)
 
 ## Q: Where can I learn how to use the AziHSM?
 
 Please see the [sample applications](../samples) in this repository.
 These provide examples of how the AziHSM can be used for various purposes.
 
-## Q: How do I collect AziHSM debug logs?
+The AziHSM KSP (Key Storage Provider) on Windows is invoked via the [Windows NCrypt API](https://learn.microsoft.com/en-us/windows/win32/api/ncrypt/), just like other NCrypt providers like KeyGuard and LSASS.
+There are a few notable differences in the behavior of the AziHSM provider when calling it via NCrypt; please see [the NCrypt differences page](./NCryptDifferences.md) for more information.
+
+## Q: Can I import and use my keys from AKV (Azure Key Vault) / mHSM (Managed Hardware Security Module)?
+
+Yes!
+Through a process known as **Secure Key Release** (**SKR**), you can perform attestation and securely import your key from AKV/mHSM into the local AziHSM device connected to your AziHSM-enabled VM.
+
+Please see the [Secure Key Release](./SecureKeyRelease.md) page to learn more.
+
+## Q: How do I collect AziHSM debug logs on my VM?
 
 Both the AziHSM KSP (Key Storage Provider) and the AziHSM device driver produce their own debug output.
 This output can be captured and viewed on your VM through [ETW (Event Tracing for Windows)](https://learn.microsoft.com/en-us/windows/win32/etw/event-tracing-portal).

--- a/docs/InstallLinux.md
+++ b/docs/InstallLinux.md
@@ -1,0 +1,5 @@
+# Installing AziHSM Dependencies on Linux VMs
+
+**NOTE**: Linux availability of AziHSM is under active development.
+For Windows support, please see the [Windows Install](./InstallWindows.md) page.
+

--- a/docs/InstallWindows.md
+++ b/docs/InstallWindows.md
@@ -1,4 +1,4 @@
-# Installing AziHSM Dependencies
+# Installing AziHSM Dependencies on Windows VMs
 
 Before you can run any of the samples in this repository, you'll need to ensure that the following dependencies are installed onto your machine:
 

--- a/docs/Overview.md
+++ b/docs/Overview.md
@@ -1,30 +1,18 @@
 # AziHSM Overview
 
-The AziHSM is a Hardware Security Module (HSM) that enables the creation, caching, and usage of cryptography keys within an isolated hardware environment.
+**Azure Integrated HSM** (**AziHSM**) is a Hardware Security Module (HSM) that enables the creation, caching, and usage of cryptography keys within an isolated hardware environment.
 Specifically, AziHSM is a physical device that is installed onto the motherboard of Azure host machines.
-Cryptographic keys and security assets are cached within the device.
+
+Azure customers can store their cryptographic keys and security assets on AziHSM.
+They can then make calls via the AziHSM guest stack to perform cryptographic operations with their keys within the local AziHSM device.
 AziHSM has several hardware cryptographic engines that perform encryption, decryption, signing, and other operations.
 
 AziHSM is designed to meet the Federal Information Processing Standards (FIPS) 140-3 Level 3 Security Requirements for Cryptographic Modules.
-Cryptographic keys and security assets *never* leave the device, which ensures they are protected while in use, and are isolated from potential adversarial attacks elsewhere on the physical machine.
+Cryptographic keys and security assets *never* leave this FIPS 140-3 security boundary, which ensures they are protected while in use, and are isolated from potential adversarial attacks elsewhere on the physical machine.
 
-If your Azure workloads heavily rely on cryptography and have performance intensive workloads, AziHSM provides a secure way to store cryptographic keys for quick and secure retrieval.
+This security guarantee, plus the performance benefits of running cryptographic operations locally (i.e within the same host machine your VM is running on), makes AziHSM an ideal choice for cryptographic-heavy workloads.
 
-## Supported Operations
+## Questions?
 
-Please see the [supported algorithms page](./SupportedAlgorithms.md) for a list of the crypto algorithms supported by AziHSM.
-
-## Supported VM SKUs
-
-Please see the [supported SKUs page](./SupportedSKUs.md) for information on the Azure VM SKUs that support AziHSM.
-
-## NCrypt API
-
-The AziHSM KSP (Key Storage Provider) on Windows is invoked via the [Windows NCrypt API](https://learn.microsoft.com/en-us/windows/win32/api/ncrypt/), just like other NCrypt providers like KeyGuard and LSASS.
-There are a few notable differences in the behavior of the AziHSM provider when calling it via NCrypt; please see [the NCrypt differences page](./NCryptDifferences.md) for more information.
-
-## Secure Key Release
-
-AziHSM supports securely releasing keys from AKV/mHSM into the AziHSM device.
-Please see the [AziHSM SKR page](./SecureKeyRelease.md) for more information.
+Please take a look at the [Frequently Asked Questions](./FAQ.md) for answers to common questions.
 

--- a/scripts/install-azihsm.ps1
+++ b/scripts/install-azihsm.ps1
@@ -784,7 +784,7 @@ function get_azihsm_device_info
 
     # Invoke the `get_device_info` utility and capture its output.
     Write-Host "Executing `"$GetDeviceInfoPath`" to retrieve connected AziHSM device information."
-    $result = run_cmd -CmdName "$GetDeviceInfoPath"
+    $result = run_cmd -CmdName "$GetDeviceInfoPath" -CmdArgs "--json"
     $out = $result.Output
 
     # If the utility didn't output anything, then it was unable to communicate
@@ -815,49 +815,37 @@ function get_azihsm_device_info
         PCIInfo = $null
     }
 
-    # Read the output line-by-line:
-    $lines = $out -split "`n"
-    $fw_version = $null
-    foreach ($line in $lines)
+    # Parse JSON output and extract the first device entry.
+    $parsed_output = $null
+    try
     {
-        # Sanitize each line of output
-        $line = $line.Trim()
-        $line = $line.Replace("`t", " ")
-
-        # Skip lines that don't have key-value pair syntax
-        if (-not ($line -match "[a-zA-Z0-9_\-\s]+:"))
-        {
-            continue
-        }
-
-        # Split the line into its key and value components
-        $pieces = $line -split ":", 2
-        $key = $pieces[0].Trim().ToLower()
-        $value = $pieces[1].Trim().Trim('"')
-
-        # Look for various keys and store their values:
-        if ($key -like "*driver version*")
-        {
-            $device_info.DriverVersion = $value
-            Write-Host "Discovered AziHSM device driver version: $value"
-        }
-        elseif ($key -like "*fw ver*")
-        {
-            $fw_version = sanitize_fw_version -FwVersion $value
-            $device_info.FirmwareVersion = $fw_version
-            Write-Host "Discovered AziHSM device firmware version: $fw_version"
-        }
-        elseif ($key -like "*hw ver*")
-        {
-            $device_info.HardwareVersion = $value
-            Write-Host "Discovered AziHSM device hardware version: $value"
-        }
-        elseif ($key -like "*pci info*")
-        {
-            $device_info.PCIInfo = $value
-            Write-Host "Discovered AziHSM device PCI info: $value"
-        }
+        $parsed_output = $out | ConvertFrom-Json -ErrorAction Stop
     }
+    catch
+    {
+        $msg = "Failed to parse JSON output from `"$GetDeviceInfoPath`"."
+        $msg = "$msg Received output:`n$out"
+        Write-Error "$msg"
+        return $null
+    }
+
+    $devices = @($parsed_output.device_info)
+    if ($devices.Length -eq 0)
+    {
+        Write-Warning "No AziHSM devices found in JSON output from `"$GetDeviceInfoPath`"."
+        return $null
+    }
+
+    $device = $devices[0]
+    $device_info.DriverVersion = [string]$device.driver_ver
+    $device_info.FirmwareVersion = sanitize_fw_version -FwVersion ([string]$device.firmware_ver)
+    $device_info.HardwareVersion = [string]$device.hardware_ver
+    $device_info.PCIInfo = [string]$device.pci_info
+
+    Write-Host "Discovered AziHSM device driver version: $($device_info.DriverVersion)"
+    Write-Host "Discovered AziHSM device firmware version: $($device_info.FirmwareVersion)"
+    Write-Host "Discovered AziHSM device hardware version: $($device_info.HardwareVersion)"
+    Write-Host "Discovered AziHSM device PCI info: $($device_info.PCIInfo)"
 
     # Make sure all fields in custom object were filled.
     if (-not $device_info.DriverVersion -or

--- a/scripts/trace-collect-start.ps1
+++ b/scripts/trace-collect-start.ps1
@@ -4,6 +4,75 @@
 # This script acts as a wrapper around the `logman` command-line utility to
 # provide an interface for dumping AzIHSM ETW log messages to a file.
 
+# Mapping of friendly tracing level names to their numeric ETW level values.
+# These values mirror the authoritative mapping used by the AzIHSM KSP ETW
+# provider in `plugins/ksp/src/etw_tracing.rs` (the `win_etw_provider::Level`
+# values): ERROR=2, WARN=3, INFO=4, DEBUG (VERBOSE)=5, TRACE=6.
+#
+# The numeric value is passed to logman as the ETW *level* cutoff. logman
+# captures every event whose level is less than or equal to the cutoff, so a
+# higher value captures that level and everything more severe (for example, a
+# cutoff of INFO/4 captures INFO, WARN, and ERROR events).
+$LEVEL_NAME_MAP = @{
+    "ERROR" = 2
+    "WARN"  = 3
+    "INFO"  = 4
+    "DEBUG" = 5
+    "TRACE" = 6
+}
+
+# Default ETW level cutoff used when the caller does not supply `-Level`. The
+# value 0xFF preserves the historical behavior of capturing every event, since
+# all real tracing levels fall well below 255.
+$DEFAULT_ETW_LEVEL = 0xFF
+
+# Maximum valid ETW level value. ETW encodes the level as a single byte, so
+# valid numeric levels fall within the inclusive range 0 - 255.
+$MAX_ETW_LEVEL = 0xFF
+
+# Helper function to resolve a caller-supplied level into a numeric ETW level
+# cutoff. The input may be a friendly name (case-insensitive: ERROR, WARN,
+# INFO, DEBUG, TRACE) or a raw numeric value in decimal (e.g. "4") or
+# hexadecimal (e.g. "0xFF") form. Returns the resolved integer, or $null when
+# the input cannot be interpreted as a valid ETW level.
+function resolve_etw_level
+{
+    Param
+    (
+        [Parameter(Mandatory=$true)]
+        [string]$Level
+    )
+
+    # friendly names take precedence and are matched case-insensitively
+    $name = $Level.Trim().ToUpper()
+    if ($LEVEL_NAME_MAP.ContainsKey($name))
+    {
+        return $LEVEL_NAME_MAP[$name]
+    }
+
+    # otherwise, interpret the value as a numeric literal (decimal or hex)
+    $numeric = 0
+    if ([int]::TryParse($Level, [ref]$numeric))
+    {
+        # decimal value parsed successfully
+    }
+    elseif ($Level -match '^0[xX][0-9a-fA-F]+$')
+    {
+        $numeric = [Convert]::ToInt32($Level, 16)
+    }
+    else
+    {
+        return $null
+    }
+
+    if ($numeric -lt 0 -or $numeric -gt $MAX_ETW_LEVEL)
+    {
+        return $null
+    }
+
+    return $numeric
+}
+
 # Helper function to launch logman.
 function launch_logman
 {
@@ -37,6 +106,14 @@ function show_help_menu
     Write-Host "-ProviderGUIDs GUID1,GUID2,..."
     Write-Host "    A list of one or more ETW provider GUID strings."
     Write-Host "    Each provider GUID will be added to the new trace session."
+    Write-Host "-Level LEVEL (optional)"
+    Write-Host "    The ETW level cutoff to capture. logman captures all events"
+    Write-Host "    whose level is at or below (more severe than) this cutoff."
+    Write-Host "    Accepts a friendly name (case-insensitive):"
+    Write-Host "        ERROR (2), WARN (3), INFO (4), DEBUG (5), TRACE (6)"
+    Write-Host "    or a raw numeric value in decimal (e.g. 4) or hex (e.g. 0xFF)."
+    Write-Host "    For example, -Level INFO captures INFO, WARN, and ERROR events."
+    Write-Host "    When omitted, every event is captured (default: 0xFF / TRACE)."
 }
 
 function main
@@ -48,8 +125,30 @@ function main
         [Parameter(Mandatory=$true)]
         [string[]]$ProviderGUIDs,
         [Parameter(Mandatory=$true)]
-        [string]$SessionName
+        [string]$SessionName,
+        [Parameter(Mandatory=$false)]
+        [string]$Level
     )
+
+    # resolve the ETW level cutoff. When -Level is omitted, fall back to the
+    # default so that every event is captured (preserving the original
+    # behavior). Any invalid input is rejected with a non-zero exit code.
+    if ([string]::IsNullOrEmpty($Level))
+    {
+        $etw_level = $DEFAULT_ETW_LEVEL
+    }
+    else
+    {
+        $etw_level = resolve_etw_level -Level $Level
+        if ($null -eq $etw_level)
+        {
+            Write-Error ("Invalid -Level value `"$Level`". Expected one of: " +
+                "$($LEVEL_NAME_MAP.Keys -join ', ') (case-insensitive), or a " +
+                "numeric value in the range 0-$MAX_ETW_LEVEL (decimal or hex, " +
+                "e.g. 0xFF).")
+            return 1
+        }
+    }
 
     # create a trace session
     $logman_args = "create trace `"$SessionName`" -ets -o `"$OutputPath`""
@@ -63,7 +162,7 @@ function main
     # for each of the GUIDs provided, update the trace to track it
     foreach ($guid in $ProviderGUIDs)
     {
-        $logman_args = "update `"$SessionName`" -ets -p `"{$guid}`" 0xFFFFFFFF 0xFF"
+        $logman_args = "update `"$SessionName`" -ets -p `"{$guid}`" 0xFFFFFFFF $etw_level"
         $ret = launch_logman -LogmanArgs "$logman_args"
         if ($ret -ne 0)
         {


### PR DESCRIPTION
This PR makes some updates to the various documents under `docs/`, updates the ARM template file, and updates `scripts/trace-collect-start.ps1` to accept a new `-Level` parameter, which allows tracing to properly filter out certain levels. This also updates the `scripts/install-azihsm.ps1` script to parse JSON from the `get_device_info.exe` tool.